### PR TITLE
Run remote script outside of the Angular zone

### DIFF
--- a/src/captcha-helper.service.ts
+++ b/src/captcha-helper.service.ts
@@ -1,18 +1,23 @@
-import { Injectable } from '@angular/core';
+import { NgZone, Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 
 @Injectable()
 export class CaptchaHelperService {
 
-  constructor(private http: HttpClient) { }
+  constructor(private http: HttpClient, private ngZone: NgZone) { }
 
   // get script and execute it immediately
   getScript(url: string, onLoadSuccess: () => void): void {
     this.http.get(url, { responseType: 'text' })
       .subscribe(
         scriptString => {
-          let f = new Function(scriptString); f();
-          setTimeout(onLoadSuccess, 200);
+          let f = new Function(scriptString);
+            this.ngZone.runOutsideAngular(() => {
+              f();
+              this.ngZone.run(() => {
+                  setTimeout(onLoadSuccess, 200);
+              });
+            });
         }
       );
   }


### PR DESCRIPTION
Running this script inside angular zone causes problems with Protractor
because there are a lot of setTimeout uses in the remote script.